### PR TITLE
containers: fix repository path

### DIFF
--- a/hack/container/buildah-push.sh
+++ b/hack/container/buildah-push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 TAGS="$*"
 for TAG in $TAGS; do
-	buildah push fromani/kvm-info-nfd-plugin:$TAG docker://quay.io/fromani/kvm-info-nfd-plugin:$TAG
+	buildah push kubevirt/kvm-info-nfd-plugin:$TAG docker://quay.io/kubevirt/kvm-info-nfd-plugin:$TAG
 done

--- a/hack/container/buildah-tag.sh
+++ b/hack/container/buildah-tag.sh
@@ -3,7 +3,7 @@
 TAG="${1:-devel}"
 XTAGS="${@:2}"  # see https://stackoverflow.com/questions/9057387/process-all-arguments-except-the-first-one-in-a-bash-script
 
-buildah bud -t fromani/kvm-info-nfd-plugin:$TAG .
+buildah bud -t kubevirt/kvm-info-nfd-plugin:$TAG .
 for XTAG in $XTAGS; do
-	buildah tag fromani/kvm-info-nfd-plugin:$TAG fromani/kvm-info-nfd-plugin:$XTAG
+	buildah tag kubevirt/kvm-info-nfd-plugin:$TAG kubevirt/kvm-info-nfd-plugin:$XTAG
 done

--- a/hack/container/docker-push.sh
+++ b/hack/container/docker-push.sh
@@ -10,6 +10,6 @@ if [ -z "$QUAY_BOT_PASS" ] || [ -z "$QUAY_BOT_USER" ]; then
 fi
 
 echo "$QUAY_BOT_PASS" | docker login -u="$QUAY_BOT_USER" --password-stdin quay.io
-docker build -t quay.io/fromani/kvm-info-nfd-plugin:$VERSION .
-docker push quay.io/fromani/kvm-info-nfd-plugin:$VERSION
+docker build -t quay.io/kubevirt/kvm-info-nfd-plugin:$VERSION .
+docker push quay.io/kubevirt/kvm-info-nfd-plugin:$VERSION
 docker logout quay.io

--- a/hack/container/podman-push.sh
+++ b/hack/container/podman-push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 TAGS="$*"
 for TAG in $TAGS; do
-	podman push fromani/kvm-info-nfd-plugin:$TAG docker://quay.io/fromani/kvm-info-nfd-plugin:$TAG
+	podman push kubevirt/kvm-info-nfd-plugin:$TAG docker://quay.io/kubevirt/kvm-info-nfd-plugin:$TAG
 done


### PR DESCRIPTION
The images now are hosted under the kubevirt umbrella.

Signed-off-by: Francesco Romani <fromani@redhat.com>