### PR TITLE
Revert "build: capsinfo as static binary"

### DIFF
--- a/hack/build/build-capsinfo.sh
+++ b/hack/build/build-capsinfo.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-gcc -static -Wall -g -Ilib -o cmd/kvm-caps-info-nfd-plugin/kvm-caps-info-nfd-plugin \
+gcc -Wall -g -Ilib -o cmd/kvm-caps-info-nfd-plugin/kvm-caps-info-nfd-plugin \
 	cmd/kvm-caps-info-nfd-plugin/main.c \
 	cmd/kvm-caps-info-nfd-plugin/kvm_io.c \
 	lib/libkvminfocaps.a


### PR DESCRIPTION
This reverts commit 07760c417439fd7827b70c2da7118a3548151d4d.