### PR TITLE
repo: enable DCO check

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+---
+require:
+  members: true


### PR DESCRIPTION
Required to be CNCF compliant. See:
https://github.com/kubevirt/project-infra/pull/189
https://github.com/kubevirt/kubevirt/issues/2678
https://github.com/apps/dco

Signed-off-by: Francesco Romani <fromani@redhat.com>